### PR TITLE
fix: only support one spanset temporarily

### DIFF
--- a/.github/workflows/prcheck.yaml
+++ b/.github/workflows/prcheck.yaml
@@ -35,7 +35,7 @@ jobs:
       run: cargo binstall -y cargo-sort
     - name: run checkers
       run: |
-        cargo sort -c
+        cargo sort -c -w
         cargo fmt -- --check
         cargo clippy -- -D warnings
         cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "common",
  "itertools 0.13.0",
  "logql",
+ "opentelemetry-proto",
  "ordered-float",
  "traceql",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ordered-float = { version = "4.2.2" }
 humantime = { version = "2.1.0" }
 chrono = { version = "0.4.38", features = ["serde"] }
 pretty_assertions = "1.4.0"
+opentelemetry-proto = { version = "0.7.0", features = ["full"] }
 
 [dependencies]
 anyhow = "1.0.86"
@@ -45,7 +46,7 @@ logql = { path = "logql" }
 moka = { version = "0.12.8", features = ["default", "sync"] }
 opentelemetry = { version = "0.24.0", features = ["metrics"] }
 opentelemetry-prometheus = "0.17.0"
-opentelemetry-proto = { version = "0.7.0", features = ["full"] }
+opentelemetry-proto = { workspace = true }
 opentelemetry-semantic-conventions = { version = "0.16.0" }
 opentelemetry_sdk = { version = "0.24.1", features = ["metrics"] }
 ordered-float = { version = "4.2.2" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,5 +6,5 @@ rust-version = "1.76.0"
 authors = ["caibirdme <492877816@qq.com>"]
 
 [dependencies]
-chrono = {workspace=true}
-anyhow = { version = "1.0.86"}
+anyhow = { version = "1.0.86" }
+chrono = { workspace = true }

--- a/logql/Cargo.toml
+++ b/logql/Cargo.toml
@@ -6,10 +6,9 @@ rust-version = "1.76.0"
 authors = ["caibirdme <492877816@qq.com>"]
 
 [dependencies]
-nom = { workspace = true }
 humantime-serde = { workspace = true }
 itertools = { workspace = true }
-
+nom = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/sqlbuilder/Cargo.toml
+++ b/sqlbuilder/Cargo.toml
@@ -7,8 +7,9 @@ authors = ["caibirdme <492877816@qq.com>"]
 
 [dependencies]
 chrono ={ workspace = true }
-ordered-float = {workspace = true}
-common = {path = "../common"}
-logql = {path = "../logql"}
-traceql = {path = "../traceql"}
+common = { path = "../common" }
 itertools = { workspace = true }
+logql = { path = "../logql" }
+opentelemetry-proto = { workspace = true }
+ordered-float = { workspace = true }
+traceql = { path = "../traceql" }

--- a/src/storage/ck/traceql_test.yaml
+++ b/src/storage/ck/traceql_test.yaml
@@ -5,6 +5,6 @@ with_duration_and_status:
     FROM otlp.otel_traces
     WHERE (ResourceAttributes['app'] = 'camp'
           AND (Duration > 90000000000
-          AND (StatusCode != 1
+          AND (StatusCode != 'STATUS_CODE_OK'
           AND ServiceName='haha'))
       ) LIMIT 500

--- a/src/storage/ck/traceql_test.yaml
+++ b/src/storage/ck/traceql_test.yaml
@@ -1,87 +1,10 @@
-three_spansets:
-  input: '{resource.app="camp" && serviceName="fooSvc"} && ({span.qwe="qqq"} || {foo>10})'
-  expect: |
-    SELECT *
-    FROM otlp.otel_traces sp
-    WHERE sp.SpanId IN
-        (SELECT SpanId
-        FROM (
-                (SELECT SpanId,
-                        TraceId
-                  FROM otlp.otel_traces
-                  WHERE (ResourceAttributes['app'] = 'camp'
-                        AND ServiceName = 'fooSvc'))
-              UNION
-                (SELECT SpanId,
-                        TraceId
-                  FROM otlp.otel_traces
-                  WHERE SpanAttributes['qwe'] = 'qqq')
-              UNION
-                (SELECT SpanId,
-                        TraceId
-                  FROM otlp.otel_traces
-                  WHERE (SpanAttributes['foo'] > 10 OR ResourceAttributes['foo']>10))) AS sub
-        WHERE (sub.TraceId IN
-                      (SELECT TraceId
-                        FROM otlp.otel_traces
-                        WHERE (ResourceAttributes['app'] = 'camp'
-                              AND ServiceName = 'fooSvc'))
-                    AND (sub.TraceId IN
-                            (SELECT TraceId
-                            FROM otlp.otel_traces
-                            WHERE SpanAttributes['qwe'] = 'qqq')
-                          OR sub.TraceId IN
-                            (SELECT TraceId
-                            FROM otlp.otel_traces
-                            WHERE (SpanAttributes['foo'] > 10 OR ResourceAttributes['foo']>10))))) LIMIT 500
-
-two_spansets:
-  input: '{resource.app="camp" && serviceName="fooSvc"} && {qwe="qqq"}'
-  expect: |
-    SELECT *
-    FROM otlp.otel_traces sp
-    WHERE sp.SpanId IN (
-      SELECT SpanId
-      FROM (
-        (SELECT SpanId, TraceId
-        FROM otlp.otel_traces
-        WHERE (ResourceAttributes['app'] = 'camp'
-          AND ServiceName = 'fooSvc'))
-        UNION
-        (SELECT SpanId, TraceId
-        FROM otlp.otel_traces
-        WHERE (SpanAttributes['qwe'] = 'qqq' OR ResourceAttributes['qwe'] = 'qqq'))
-      ) AS sub
-      WHERE (sub.TraceId IN (
-            SELECT TraceId
-            FROM otlp.otel_traces
-            WHERE (ResourceAttributes['app'] = 'camp'
-              AND ServiceName = 'fooSvc')
-          )
-          AND sub.TraceId IN (
-            SELECT TraceId
-            FROM otlp.otel_traces
-            WHERE (SpanAttributes['qwe'] = 'qqq' OR ResourceAttributes['qwe'] = 'qqq')
-          ))) LIMIT 500
-
 with_duration_and_status:
-  input: '{resource.app="camp" && duration > 90s && status!=ok}'
+  input: '{resource.app="camp" && duration > 90s && status!=ok && serviceName="haha"}'
   expect: |
-    SELECT *
-    FROM otlp.otel_traces sp
-    WHERE sp.SpanId IN (
-      SELECT SpanId
-      FROM (
-        (SELECT SpanId, TraceId
-        FROM otlp.otel_traces
-        WHERE (ResourceAttributes['app'] = 'camp'
+    SELECT Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind, ServiceName, ResourceAttributes, ScopeName, ScopeVersion, SpanAttributes, Duration, StatusCode, StatusMessage, Events.Timestamp, Events.Name, Events.Attributes, Links.TraceId, Links.SpanId, Links.TraceState, Links.Attributes
+    FROM otlp.otel_traces
+    WHERE (ResourceAttributes['app'] = 'camp'
           AND (Duration > 90000000000
-          AND StatusCode != 1)))
-      ) AS sub
-      WHERE sub.TraceId IN (
-            SELECT TraceId
-            FROM otlp.otel_traces
-            WHERE (ResourceAttributes['app'] = 'camp'
-              AND (Duration > 90000000000
-              AND StatusCode != 1))
-          )) LIMIT 500
+          AND (StatusCode != 1
+          AND ServiceName='haha'))
+      ) LIMIT 500

--- a/traceql/Cargo.toml
+++ b/traceql/Cargo.toml
@@ -6,10 +6,9 @@ rust-version = "1.76.0"
 authors = ["caibirdme <492877816@qq.com>"]
 
 [dependencies]
+humantime = { workspace = true }
 nom = { workspace = true }
 ordered-float = { workspace = true }
-humantime = { workspace = true }
-
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }


### PR DESCRIPTION
Since it's hard to run very complex distributed join in clickhouse, we temporarily limit only one snanset when searching for span 

```traceql
// this is ok
{foo="1" && bar="2" && duration>100ms && status=error}

// this is prohibited for now
{foo="1"} && {bar="2"}
```