### PR TITLE
feat: add ARM64 support for Docker builds

### DIFF
--- a/.github/workflows/auto-docker.yml
+++ b/.github/workflows/auto-docker.yml
@@ -39,7 +39,7 @@ jobs:
         packages: write
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -81,6 +81,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ fromJSON('{"aarch64-unknown-linux-gnu":"linux/arm64","x86_64-unknown-linux-gnu":"linux/amd64","x86_64-unknown-linux-musl":"linux/amd64"}')[matrix.target] }}
+
+      - name: Set up QEMU
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: docker/setup-qemu-action@v3
 
       - name: Docker Buildx cache
         uses: actions/cache@v3
@@ -102,6 +108,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: ${{ fromJSON('{"aarch64-unknown-linux-gnu":"linux/arm64","x86_64-unknown-linux-gnu":"linux/amd64","x86_64-unknown-linux-musl":"linux/amd64"}')[matrix.target] }}
           tags: ghcr.io/${{ github.repository }}:latest-${{ matrix.target }}
           file: docker/${{ matrix.target }}/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -20,7 +20,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu]
       fail-fast: false
     
     steps:
@@ -64,6 +64,12 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        platforms: ${{ fromJSON('{"aarch64-unknown-linux-gnu":"linux/arm64","x86_64-unknown-linux-gnu":"linux/amd64","x86_64-unknown-linux-musl":"linux/amd64"}')[matrix.target] }}
+
+    - name: Set up QEMU
+      if: matrix.target == 'aarch64-unknown-linux-gnu'
+      uses: docker/setup-qemu-action@v3
 
     - name: Docker Buildx cache
       uses: actions/cache@v3
@@ -85,6 +91,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: ${{ fromJSON('{"aarch64-unknown-linux-gnu":"linux/arm64","x86_64-unknown-linux-gnu":"linux/amd64","x86_64-unknown-linux-musl":"linux/amd64"}')[matrix.target] }}
         tags: ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag }}-${{ matrix.target }}
         file: docker/${{ matrix.target }}/Dockerfile
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -17,7 +17,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu]
     
     steps:
     - name: Checkout repository
@@ -64,6 +64,8 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        platforms: ${{ fromJSON('{"aarch64-unknown-linux-gnu":"linux/arm64","x86_64-unknown-linux-gnu":"linux/amd64","x86_64-unknown-linux-musl":"linux/amd64"}')[matrix.target] }}
 
     - name: Docker Buildx cache
       uses: actions/cache@v3
@@ -80,11 +82,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      if: matrix.target == 'aarch64-unknown-linux-gnu'
+      uses: docker/setup-qemu-action@v3
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
         context: .
         push: true
+        platforms: ${{ fromJSON('{"aarch64-unknown-linux-gnu":"linux/arm64","x86_64-unknown-linux-gnu":"linux/amd64","x86_64-unknown-linux-musl":"linux/amd64"}')[matrix.target] }}
         tags: |
           ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}
           ghcr.io/${{ github.repository }}:latest-${{ matrix.target }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,6 @@ image = "caibirdme11/cross-gnu:v0.0.1"
 
 [target.x86_64-unknown-linux-musl]
 image = "caibirdme11/cross-musl:v0.0.1"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest"

--- a/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim
+
+WORKDIR /app
+
+COPY ./target/aarch64-unknown-linux-gnu/release/ltbridge ./ltbridge
+
+ENTRYPOINT ["./ltbridge"] 


### PR DESCRIPTION
- Add aarch64-unknown-linux-gnu target in Cross.toml

- Update GitHub Actions workflows to support ARM64 builds

- Add Dockerfile for aarch64 target

- Configure multi-platform builds with QEMU